### PR TITLE
bug(CX-9999): changed const to var

### DIFF
--- a/v2/script.js
+++ b/v2/script.js
@@ -9,7 +9,7 @@ if (site && username) {
 
     lpTag.identities = [];
     lpTag.identities.push(identityFn);
-    const usernameResult = 'lpTest' + username;
+    var usernameResult = 'lpTest' + username;
 
     function identityFn(callback) {
         callback({


### PR DESCRIPTION
Changed `const` to `var` because browsers like safari cannot seem to reference the declared variable inside of a function