### PR TITLE
Add smtDebug flag to debug Shark monitoring protocol

### DIFF
--- a/lpwma/index.html
+++ b/lpwma/index.html
@@ -90,5 +90,16 @@ window.lpTag=window.lpTag||{},"undefined"==typeof window.lpTag._tagCount?(window
 
 <script src="../script.js"></script>
 
+<script>
+    (function() {
+        const smtDebugParam = (new URLSearchParams(window.location.search)).get('smtDebug');
+        if (smtDebugParam === 'true') {
+            const script = document.createElement('script');
+            script.src = '../smtDebug.js';
+            document.head.appendChild(script);
+        }
+    })();
+</script>
+
 </body>
 </html>

--- a/lpwma/index.html
+++ b/lpwma/index.html
@@ -92,10 +92,10 @@ window.lpTag=window.lpTag||{},"undefined"==typeof window.lpTag._tagCount?(window
 
 <script>
     (function() {
-        const smtDebugParam = (new URLSearchParams(window.location.search)).get('smtDebug');
-        if (smtDebugParam === 'true') {
+        const smtDebugParam = (new URLSearchParams(window.location.search)).get('lpDebug');
+        if (smtDebugParam === '3') {
             const script = document.createElement('script');
-            script.src = '../smtDebug.js';
+            script.src = '../../smtDebug.js';
             document.head.appendChild(script);
         }
     })();

--- a/lpwmqa/index.html
+++ b/lpwmqa/index.html
@@ -90,10 +90,10 @@ window.lpTag=window.lpTag||{},"undefined"==typeof window.lpTag._tagCount?(window
 
 <script>
     (function() {
-        const smtDebugParam = (new URLSearchParams(window.location.search)).get('smtDebug');
-        if (smtDebugParam === 'true') {
+        const smtDebugParam = (new URLSearchParams(window.location.search)).get('lpDebug');
+        if (smtDebugParam === '3') {
             const script = document.createElement('script');
-            script.src = '../smtDebug.js';
+            script.src = '../../smtDebug.js';
             document.head.appendChild(script);
         }
     })();

--- a/lpwmqa/index.html
+++ b/lpwmqa/index.html
@@ -88,5 +88,16 @@ window.lpTag=window.lpTag||{},"undefined"==typeof window.lpTag._tagCount?(window
 
 <script src="../script.js"></script>
 
+<script>
+    (function() {
+        const smtDebugParam = (new URLSearchParams(window.location.search)).get('smtDebug');
+        if (smtDebugParam === 'true') {
+            const script = document.createElement('script');
+            script.src = '../smtDebug.js';
+            document.head.appendChild(script);
+        }
+    })();
+</script>
+
 </body>
 </html>

--- a/smtDebug.js
+++ b/smtDebug.js
@@ -1,0 +1,124 @@
+// Check if the top-level object "smtDebug" exists, if not, create it
+if (typeof lpSMTDebug === 'undefined') {
+    var lpSMTDebug = {};
+}
+
+// Initialize the JSONP array if it doesn't exist
+if (!lpSMTDebug.jsonpArray) {
+    lpSMTDebug.jsonpArray = [];
+}
+
+// Initialize helper function object if it doesn't exist
+if (!lpSMTDebug.helpers) {
+    lpSMTDebug.helpers = {};
+}
+
+// Extract query parameters from the request URL
+lpSMTDebug.helpers.extractQueryParams = function(requestUrl) {
+    var queryParams = {};
+    var queryString = requestUrl.split('?')[1];
+
+    if (queryString) {
+        var pairs = queryString.split('&');
+        pairs.forEach(function (pair) {
+            var parts = pair.split('=');
+            queryParams[decodeURIComponent(parts[0])] = decodeURIComponent(parts[1] || '');
+        });
+    }
+
+    return queryParams;
+}
+
+// Function to extract response code from the JSON response body
+lpSMTDebug.helpers.extractResponseCode = function(responseBody) {
+    var responseCode = null;
+
+    try {
+        var jsonResponse = JSON.parse(responseBody);
+        if (jsonResponse && jsonResponse.code) {
+            responseCode = jsonResponse.code;
+        }
+    } catch (error) {
+        // Handle parsing error if necessary
+    }
+
+    return responseCode;
+}
+
+const changeListeners = []
+
+const notifyChange = (jsonpArray) => {
+    changeListeners.forEach((listener) => {
+        listener(jsonpArray);
+    });
+}
+
+lpSMTDebug.helpers.subscribeChangeListener = function (listener) {
+    changeListeners.push(listener);
+}
+
+// Function to add new jsonp objects to an array
+lpSMTDebug.helpers.addJsonp = function (requestUrl, responseBody, startTimestamp, endTimestamp) {
+    // Create an object to store jsonp data
+    var jsonpObject = {
+        requestUrl: requestUrl,
+        requestParams: lpSMTDebug.helpers.extractQueryParams(requestUrl),
+        responseBody: responseBody,
+        responseCode: lpSMTDebug.helpers.extractResponseCode(responseBody),
+        startTimestamp: startTimestamp,
+        endTimestamp: endTimestamp
+    };
+
+    // Add jsonp object to the array
+    lpSMTDebug.jsonpArray.push(jsonpObject);
+    notifyChange(jsonpObject);
+};
+
+function isPathSharkJSONP(url) {
+    try {
+        const path = (new URL(url)).pathname;
+        return path.startsWith("/api/js");
+    } catch(ex) {
+        // not a valid url
+        return false;
+    }
+}
+
+// Create a callback function that will be invoked when mutations occur
+// Specifically, look for JSONP script tags added to the DOM
+function domMutationCallback(mutationsList, observer) {
+    // Loop through the list of mutations
+    for (const mutation of mutationsList) {
+        if (mutation.type === 'childList') {
+            for (const node of mutation.addedNodes) {
+                if (node.nodeName === 'SCRIPT' && node.attributes['src']) {
+                    // Check for SMT API JSONP script tags
+                    const urlAttrib = node.attributes['src'].value;
+                    if (urlAttrib && isPathSharkJSONP(urlAttrib)) {
+                        const startTimestamp = Date.now();
+                        const urlParams = new URLSearchParams(urlAttrib);
+                        const cb = urlParams.get('cb');
+                        const originalFunctionReference = window[cb];
+                        window[cb] = function (jsonResponse) {
+                            lpSMTDebug.helpers.addJsonp(urlAttrib, jsonResponse, startTimestamp, Date.now());
+                            originalFunctionReference(jsonResponse);
+                        };
+                    } else {
+                        console.debug(`Loaded script is not a Shark SMT match: ${urlAttrib}`);
+                    }
+                }
+            }
+        }
+    }
+}
+
+// Create a MutationObserver instance with the callback function
+const observer = new MutationObserver(domMutationCallback);
+
+const targetNode = document;
+const options = {
+    childList: true, 
+    subtree: true 
+};
+
+observer.observe(targetNode, options);

--- a/v2/lpwma/index.html
+++ b/v2/lpwma/index.html
@@ -344,6 +344,17 @@
 
 <script src="../../v2/script.js"></script>
 
+<script>
+    (function() {
+        const smtDebugParam = (new URLSearchParams(window.location.search)).get('smtDebug');
+        if (smtDebugParam === 'true') {
+            const script = document.createElement('script');
+            script.src = '../../smtDebug.js';
+            document.head.appendChild(script);
+        }
+    })();
+</script>
+
 <!--<script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>-->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
 <script src="../js/bootstrap.min.js"></script>

--- a/v2/lpwma/index.html
+++ b/v2/lpwma/index.html
@@ -346,8 +346,8 @@
 
 <script>
     (function() {
-        const smtDebugParam = (new URLSearchParams(window.location.search)).get('smtDebug');
-        if (smtDebugParam === 'true') {
+        const smtDebugParam = (new URLSearchParams(window.location.search)).get('lpDebug');
+        if (smtDebugParam === '3') {
             const script = document.createElement('script');
             script.src = '../../smtDebug.js';
             document.head.appendChild(script);

--- a/v2/lpwmqa/index.html
+++ b/v2/lpwmqa/index.html
@@ -349,8 +349,8 @@
 
 <script>
     (function() {
-        const smtDebugParam = (new URLSearchParams(window.location.search)).get('smtDebug');
-        if (smtDebugParam === 'true') {
+        const smtDebugParam = (new URLSearchParams(window.location.search)).get('lpDebug');
+        if (smtDebugParam === '3') {
             const script = document.createElement('script');
             script.src = '../../smtDebug.js';
             document.head.appendChild(script);

--- a/v2/lpwmqa/index.html
+++ b/v2/lpwmqa/index.html
@@ -347,6 +347,17 @@
 });</script>
 <script src="../../v2/script.js"></script>
 
+<script>
+    (function() {
+        const smtDebugParam = (new URLSearchParams(window.location.search)).get('smtDebug');
+        if (smtDebugParam === 'true') {
+            const script = document.createElement('script');
+            script.src = '../../smtDebug.js';
+            document.head.appendChild(script);
+        }
+    })();
+</script>
+
 <!--<script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>-->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
 <script src="../js/bootstrap.min.js"></script>


### PR DESCRIPTION
If "smtDebug=true" is added as a query parameter to the URL, we **optionally** inject a new script that observes DOM mutations for Shark SMT API JSONP requests and responses, then add a lpSMTDebug object to the page.