### PR TITLE
WEB-146: Revert color changes to v2 WX tests page

### DIFF
--- a/v2/css/style.css
+++ b/v2/css/style.css
@@ -662,20 +662,3 @@ a {
 .ga-page #embedded-engagement-header {
     background-image: linear-gradient(314deg, #5a8f7b, #6c757d, #28a745);
 }
-
-/* --- QA Page (Steel Blue Theme) --- */
-.qa-page #web-message-ex-top {
-    background-color: #4682B4; /* A professional, muted steel blue */
-}
-
-.qa-page #lp_btn_login,
-.qa-page #lp_btn_inject {
-    background-color: #4682B4; /* Matching steel blue for buttons */
-}
-
-.qa-page #account_setup,
-.qa-page .modal-setup,
-.qa-page #embedded-engagement-header {
-    /* A new, calmer gradient */
-    background-image: linear-gradient(314deg, #4682B4, #5F9EA0, #708090);
-}

--- a/v2/css/style.css
+++ b/v2/css/style.css
@@ -626,39 +626,3 @@ a {
 /*opacity: 0.5;*/
 /*}*/
 /*}*/
-
-/* ==========================================================================
-   ENVIRONMENT-SPECIFIC OVERRIDES
-   ========================================================================== */
-
-/* --- Alpha Page (Deep Indigo Theme) --- */
-.alpha-page #web-message-ex-top {
-    background-color: #6f42c1;
-}
-
-.alpha-page #lp_btn_login,
-.alpha-page #lp_btn_inject {
-    background-color: #6f42c1;
-}
-
-.alpha-page #account_setup,
-.alpha-page .modal-setup,
-.alpha-page #embedded-engagement-header {
-    background-image: linear-gradient(314deg, #2c1e3e, #4a2f6c, #6f42c1);
-}
-
-/* --- GA Page (Calm Green Theme) --- */
-.ga-page #web-message-ex-top {
-    background-color: #28a745;
-}
-
-.ga-page #lp_btn_login,
-.ga-page #lp_btn_inject {
-    background-color: #28a745;
-}
-
-.ga-page #account_setup,
-.ga-page .modal-setup,
-.ga-page #embedded-engagement-header {
-    background-image: linear-gradient(314deg, #5a8f7b, #6c757d, #28a745);
-}

--- a/v2/lpwm/index.html
+++ b/v2/lpwm/index.html
@@ -59,7 +59,7 @@
     </script>
     <!-- END LivePerson Monitor. -->
 </head>
-<body class="ga-page">
+<body>
 <div class="container">
     <div class="row" >
         <div class="col-md-8" id="web-message-ex-top" >

--- a/v2/lpwma/index.html
+++ b/v2/lpwma/index.html
@@ -55,7 +55,7 @@
     </script>
     <!-- END LivePerson Monitor. -->
 </head>
-<body class="alpha-page">
+<body>
 
 
 <div class="container">

--- a/v2/lpwmqa/index.html
+++ b/v2/lpwmqa/index.html
@@ -57,7 +57,7 @@
     <!-- END LivePerson Monitor. -->
 </head>
 
-<body class="qa-page">
+<body>
 
 
 <div class="container">


### PR DESCRIPTION
Reverts [WEB-146](https://l-p.atlassian.net/browse/WEB-146): _"differentiate more clearly between web-messaging pages in alpha and prod"_
- These color changes were not effective and stakeholders were still sometimes using the wrong page per environment. 
- Reverting in preparation to perform more optimal changes in [WEB-152](https://l-p.atlassian.net/browse/WEB-152): _"WX test pages: make the environment label more prominent"_